### PR TITLE
fix not assign external ip case.(gce-host -j)

### DIFF
--- a/lib/gce/host/host_data.rb
+++ b/lib/gce/host/host_data.rb
@@ -64,11 +64,14 @@ class GCE
       end
 
       def public_ip_address
-        instance.network_interfaces.first.access_configs.first.nat_ip
+        access_configs = instance.network_interfaces.first.access_configs
+        access_configs ? access_configs.first.nat_ip : nil
       end
 
       def public_ip_addresses
-        instance.network_interfaces.map {|i| i.access_configs.map(&:nat_ip) }.flatten(1)
+        instance.network_interfaces.map {|i|
+          i.access_configs ? i.access_configs.map(&:nat_ip) : nil
+        }.flatten(1).compact
       end
 
       def creation_timestamp


### PR DESCRIPTION
hi.

We started using cloud-nat.
https://cloud.google.com/nat/docs/overview

this case is not need external ip address.

If external ip not exists this error. (use gce-host -j)
```
Traceback (most recent call last):
	7: from /opt/gcp-tools/bin/gce-host:29:in `<main>'
	6: from /opt/gcp-tools/bin/gce-host:29:in `load'
	5: from /opt/gcp-tools/vendor/bundle/ruby/2.5.0/gems/analytics-gcp-tools-1.2.1/exe/gce-host:11:in `<top (required)>'
	4: from /opt/gcp-tools/vendor/bundle/ruby/2.5.0/gems/gce-host-0.5.5/lib/gce/host/cli.rb:110:in `run'
	3: from /opt/gcp-tools/vendor/bundle/ruby/2.5.0/gems/gce-host-0.5.5/lib/gce/host/cli.rb:110:in `each'
	2: from /opt/gcp-tools/vendor/bundle/ruby/2.5.0/gems/gce-host-0.5.5/lib/gce/host/cli.rb:111:in `block in run'
	1: from /opt/gcp-tools/vendor/bundle/ruby/2.5.0/gems/gce-host-0.5.5/lib/gce/host/host_data.rb:141:in `to_hash'
/opt/gcp-tools/vendor/bundle/ruby/2.5.0/gems/gce-host-0.5.5/lib/gce/host/host_data.rb:67:in `public_ip_address': undefined method `first' for nil:NilClass (NoMethodError)
```
